### PR TITLE
Autoscale max visible suggestions to terminal height

### DIFF
--- a/option.go
+++ b/option.go
@@ -190,9 +190,13 @@ func OptionScrollbarBGColor(x Color) Option {
 }
 
 // OptionMaxSuggestion specify the max number of displayed suggestions.
+// This acts as an upper bound: the renderer shrinks the number of visible
+// suggestions to fit the terminal height (see Render), so the prompt stays
+// usable in a small window without requiring room for the full count.
 func OptionMaxSuggestion(x uint16) Option {
 	return func(p *Prompt) error {
 		p.completion.max = x
+		p.renderer.maxSuggestion = x
 		return nil
 	}
 }

--- a/render.go
+++ b/render.go
@@ -21,6 +21,7 @@ type Render struct {
 	previousCursor int
 	headerLines    int           // number of terminal lines the current header occupies; 0 = no header
 	headerCallback func() string // returns header text; may contain newlines; empty = no header
+	maxSuggestion  uint16        // configured upper bound for visible suggestions (0 = unset/no autoscale)
 
 	// colors,
 	prefixTextColor              Color
@@ -199,6 +200,25 @@ func (r *Render) Render(buffer *Buffer, completion *CompletionManager) {
 
 	// prepare area
 	_, y := r.toPos(cursor)
+
+	// Autoscale the visible suggestion count to the available terminal height
+	// so the prompt stays usable in a small window. maxSuggestion is the
+	// configured upper bound (OptionMaxSuggestion); shrink it to fit but never
+	// below 1. completion.max also drives the scroll math in CompletionManager,
+	// so updating it here keeps scrolling consistent. Render runs on every
+	// SIGWINCH, so this re-adapts on live window resize.
+	if r.maxSuggestion > 0 {
+		available := int(r.row) - y - 1 - newHeaderLines
+		if available < 1 {
+			available = 1
+		}
+		if int(r.maxSuggestion) > available {
+			completion.max = uint16(available)
+		} else {
+			completion.max = r.maxSuggestion
+		}
+	}
+
 	h := y + 1 + int(completion.max) + newHeaderLines
 	if h > int(r.row) || completionMargin > int(r.col) {
 		r.renderWindowTooSmall()

--- a/render_autoscale_test.go
+++ b/render_autoscale_test.go
@@ -1,0 +1,93 @@
+package prompt
+
+import (
+	"syscall"
+	"testing"
+)
+
+// makeAutoscaleRender builds a Render wired to a harmless writer (stdin) with a
+// fixed configured max suggestion cap, mirroring how vtb configures the prompt
+// via OptionMaxSuggestion.
+func makeAutoscaleRender(row, col, maxSuggestion uint16, header func() string) *Render {
+	return &Render{
+		prefix:                       "> ",
+		out:                          &PosixWriter{fd: syscall.Stdin},
+		livePrefixCallback:           func() (string, bool) { return "", false },
+		headerCallback:               header,
+		maxSuggestion:                maxSuggestion,
+		row:                          row,
+		col:                          col,
+		prefixTextColor:              Blue,
+		prefixBGColor:                DefaultColor,
+		inputTextColor:               DefaultColor,
+		inputBGColor:                 DefaultColor,
+		previewSuggestionTextColor:   Green,
+		previewSuggestionBGColor:     DefaultColor,
+		suggestionTextColor:          White,
+		suggestionBGColor:            Cyan,
+		selectedSuggestionTextColor:  Black,
+		selectedSuggestionBGColor:    Turquoise,
+		descriptionTextColor:         Black,
+		descriptionBGColor:           Turquoise,
+		selectedDescriptionTextColor: White,
+		selectedDescriptionBGColor:   Cyan,
+		scrollbarThumbColor:          DarkGray,
+		scrollbarBGColor:             Cyan,
+	}
+}
+
+// completionWith returns a CompletionManager already populated with n suggestions.
+func completionWith(n int, max uint16) *CompletionManager {
+	suggests := make([]Suggest, n)
+	for i := range suggests {
+		suggests[i] = Suggest{Text: "cmd", Description: "desc"}
+	}
+	c := NewCompletionManager(func(Document) []Suggest { return suggests }, max)
+	c.Update(*NewDocument())
+	return c
+}
+
+func TestRenderAutoscalesMaxSuggestion(t *testing.T) {
+	const configured uint16 = 20
+
+	cases := []struct {
+		name   string
+		row    uint16
+		header func() string
+		want   uint16
+	}{
+		// Tall window: full configured cap is honored.
+		{"tall window keeps configured cap", 50, nil, 20},
+		// Short window, no header: input line (1) leaves row-1 for suggestions.
+		{"short window clamps to fit", 10, nil, 9},
+		// Very short window still shows at least one suggestion.
+		{"tiny window floors at 1", 2, nil, 1},
+		// Header eats into the available height.
+		{"single-line header reduces room", 10, func() string { return "ENV:prod | ORG:x" }, 8},
+		// Exactly enough room for the full cap.
+		{"exact fit keeps cap", 21, nil, 20},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := completionWith(30, configured)
+			r := makeAutoscaleRender(tc.row, 80, configured, tc.header)
+			r.Render(NewBuffer(), c)
+			if c.max != tc.want {
+				t.Errorf("row=%d header=%v: completion.max = %d, want %d",
+					tc.row, tc.header != nil, c.max, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderNoAutoscaleWhenUnset verifies behavior is unchanged for consumers
+// that never call OptionMaxSuggestion (maxSuggestion == 0).
+func TestRenderNoAutoscaleWhenUnset(t *testing.T) {
+	c := completionWith(30, 6)
+	r := makeAutoscaleRender(10, 80, 0 /* unset */, nil)
+	r.Render(NewBuffer(), c)
+	if c.max != 6 {
+		t.Errorf("with maxSuggestion unset, completion.max should stay 6, got %d", c.max)
+	}
+}


### PR DESCRIPTION
## Problem

`OptionMaxSuggestion` currently behaves as a *fixed* count. The renderer reserves room for the full number of suggestions (vtb uses 20), and if the terminal can't fit `input line + maxSuggestion + header lines`, the entire prompt bails out with `Your console window is too small...`. This forces users to keep a large console window just to use vtb in interactive mode.

## Change

Treat the configured `OptionMaxSuggestion` value as an **upper bound** rather than a fixed requirement:

- Store the configured cap on the `Render` (`maxSuggestion`).
- On every `Render()`, shrink `completion.max` to the available terminal height (`row - inputLine - headerLines`), floored at 1.

Why this is correct and complete:

- `completion.max` is also what the scroll math in `CompletionManager` (`Next`/`Previous`/`update`) keys off, so updating it in one place keeps rendering **and** scrolling consistent — you can still scroll through all suggestions, just within a smaller window.
- `Render()` runs on every keystroke **and** every `SIGWINCH`, so the suggestion count **re-adapts live on window resize**.
- The `if maxSuggestion > 0` guard means behavior is unchanged for any consumer that never calls `OptionMaxSuggestion`.
