### PR TITLE
Update CODEOWNERS to vtb owners + security

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,10 @@
 # CODEOWNERS
+#
+# This is a Verkada-owned fork of go-prompt, consumed primarily by vtb
+# (Verkada-Backend: engtools/vtb). Owners mirror the vtb owners so changes
+# route to the teams that actually depend on this library, plus security.
+#
+# NOTE: GitHub applies only the last matching pattern, so all owners for a
+# path must be on a single line (do not split across multiple `*` lines).
 
-* @verkada/Backend-Infrastructure
-* @verkada/security-eng
+* @verkada/eng-tools @verkada/devx-command-tools @verkada/security-eng


### PR DESCRIPTION
## Why

This is a Verkada-owned fork of go-prompt, consumed primarily by **vtb** (`Verkada-Backend: engtools/vtb`). The owners should mirror the vtb owners so changes route to the teams that actually depend on this library.

## Change

```
* @verkada/eng-tools @verkada/devx-command-tools @verkada/security-eng
```

- Adds the vtb owners (`@verkada/eng-tools`, `@verkada/devx-command-tools`); keeps `@verkada/security-eng`.
- **Fixes a latent bug:** the previous file used two separate `*` lines. GitHub only honors the *last* matching pattern, so `@verkada/Backend-Infrastructure` was silently never enforced. All owners are now on one line, with a comment warning against splitting owners across multiple `*` lines.

Split out from the autoscale PR (#4) per review preference.