### PR TITLE
Prompt rendering and word-motion key improvements

### DIFF
--- a/input.go
+++ b/input.go
@@ -164,6 +164,21 @@ var ASCIISequences = []*ASCIICode{
 	{Key: ControlRight, ASCIICode: []byte{0x1b, 0x5b, 0x4f, 0x63}}, // rxvt
 	{Key: ControlLeft, ASCIICode: []byte{0x1b, 0x5b, 0x4f, 0x64}},  // rxvt
 
+	// macOS Option/Alt + Left/Right for word-wise motion.
+	// Terminal.app and iTerm2 send Meta-b / Meta-f (ESC b / ESC f) by default;
+	// some configs instead send the CSI "alt" variants (modifier parameter 3).
+	// Map them all to ControlLeft/ControlRight, which are bound to word motion.
+	{Key: ControlLeft, ASCIICode: []byte{0x1b, 0x62}},                          // Option/Alt + Left (Meta-b)
+	{Key: ControlRight, ASCIICode: []byte{0x1b, 0x66}},                         // Option/Alt + Right (Meta-f)
+	{Key: ControlLeft, ASCIICode: []byte{0x1b, 0x5b, 0x31, 0x3b, 0x33, 0x44}},  // Alt + Left (CSI 1;3D)
+	{Key: ControlRight, ASCIICode: []byte{0x1b, 0x5b, 0x31, 0x3b, 0x33, 0x43}}, // Alt + Right (CSI 1;3C)
+
+	// macOS Option/Alt + Backspace sends Meta-DEL (ESC DEL).
+	// Treat it as "delete the word before the cursor" (ControlW, which the
+	// default Emacs key-bind mode binds to word deletion) instead of inserting
+	// the raw bytes.
+	{Key: ControlW, ASCIICode: []byte{0x1b, 0x7f}}, // Option/Alt + Backspace (Meta-DEL)
+
 	{Key: Ignore, ASCIICode: []byte{0x1b, 0x5b, 0x45}}, // Xterm
 	{Key: Ignore, ASCIICode: []byte{0x1b, 0x5b, 0x46}}, // Linux console
 }

--- a/key_bind.go
+++ b/key_bind.go
@@ -56,4 +56,14 @@ var commonKeyBindings = []KeyBind{
 		Key: Left,
 		Fn:  GoLeftChar,
 	},
+	// Ctrl/Option + Right: forward one word (macOS Option+Right, Alt+f).
+	{
+		Key: ControlRight,
+		Fn:  GoRightWord,
+	},
+	// Ctrl/Option + Left: backward one word (macOS Option+Left, Alt+b).
+	{
+		Key: ControlLeft,
+		Fn:  GoLeftWord,
+	},
 }

--- a/render.go
+++ b/render.go
@@ -71,6 +71,29 @@ func (r *Render) renderHeader(header string) {
 	r.out.SetColor(DefaultColor, DefaultColor, false)
 }
 
+// headerLineCount returns the number of physical terminal rows the header will
+// occupy once printed, accounting for logical lines that wrap because they are
+// wider than the current terminal width.
+func (r *Render) headerLineCount(header string) int {
+	if header == "" {
+		return 0
+	}
+	col := int(r.col)
+	if col <= 0 {
+		return strings.Count(header, "\n") + 1
+	}
+	rows := 0
+	for _, line := range strings.Split(header, "\n") {
+		w := runewidth.StringWidth(line)
+		if w <= col {
+			rows++
+		} else {
+			rows += (w + col - 1) / col
+		}
+	}
+	return rows
+}
+
 // TearDown to clear title and erasing.
 func (r *Render) TearDown() {
 	r.out.ClearTitle()
@@ -101,6 +124,12 @@ func (r *Render) renderWindowTooSmall() {
 }
 
 func (r *Render) renderCompletion(buf *Buffer, completions *CompletionManager) {
+	// max == 0 disables completion entirely; draw no dropdown at all. Otherwise
+	// the dropdown renders as usual, capped at completions.max rows (set via
+	// OptionMaxSuggestion).
+	if completions.max == 0 {
+		return
+	}
 	suggestions := completions.GetSuggestions()
 	if len(completions.GetSuggestions()) == 0 {
 		return
@@ -193,10 +222,13 @@ func (r *Render) Render(buffer *Buffer, completion *CompletionManager) {
 	if r.headerCallback != nil {
 		header = r.headerCallback()
 	}
-	newHeaderLines := 0
-	if header != "" {
-		newHeaderLines = strings.Count(header, "\n") + 1
-	}
+	// Count the *physical* rows the header occupies, not just its logical lines.
+	// When the header is wider than the terminal it wraps onto multiple rows;
+	// tracking only logical lines made the next render's CursorUp undershoot, so
+	// EraseDown left the wrapped portion on screen and the header line duplicated
+	// on every keystroke. It also keeps the autoscale and window-too-small math
+	// below accurate for wrapping headers.
+	newHeaderLines := r.headerLineCount(header)
 
 	// prepare area
 	_, y := r.toPos(cursor)


### PR DESCRIPTION
## Summary

Improvements to the interactive prompt rendering and key handling, driven by usage in `vtb` (Verkada-Backend). All changes are general-purpose and the existing test suite passes.

Rebased onto `main`, which now autoscales the visible suggestion count to the terminal height (#4). That handles the "Your console window is too small..." takeover gracefully — by shrinking the suggestion list to fit rather than suppressing the safety check — so this PR **no longer adds an `OptionDisableWindowTooSmallMessage` opt-out** (dropped in favor of the autoscale). The takeover now only fires in degenerate windows (narrower than the 4-column completion margin, or too short to fit even the header), where rendering nothing sensible is the correct behavior anyway.

### render.go
- **Skip the completion dropdown entirely when `max == 0`**, so consumers can turn suggestions off via `OptionMaxSuggestion(0)`.
- **Fix header line duplication** when the header is wider than the terminal. Header height was tracked as logical lines (always 1), ignoring wrapping; the next render's `CursorUp` then undershot and `EraseDown` left the wrapped portion on screen, duplicating the header on every keystroke. Now counts the header's physical (wrapped) rows — which also keeps the autoscale and window-too-small math accurate for wrapping headers.

### input.go / key_bind.go
- **macOS Option+Left / Option+Right → word motion.** Map Meta-b/Meta-f (`ESC b`/`ESC f`) and the CSI `1;3D`/`1;3C` alt variants to `ControlLeft`/`ControlRight`, and bind those to `GoLeftWord`/`GoRightWord` in the common key bindings (so Ctrl+Left/Right also do word motion).
- **macOS Option+Backspace → delete previous word.** Map Meta-DEL (`ESC DEL`) to `ControlW`.

  These sequences were previously unmapped, so `GetKey` returned `NotDefined` and the raw escape bytes were inserted into the buffer.

## Testing
`go build ./...`, `go vet ./...`, and `go test ./...` all pass (including the autoscale test from #4); `gofmt` clean.

## Context
Consumed by https://github.com/verkada/Verkada-Backend/pull/172386. Once this merges and is tagged (e.g. `v1.0.3`), that PR will bump the dependency and drop its temporary `module_override` patch.